### PR TITLE
Enabling search by variants and adding orthographic variants to palabra view

### DIFF
--- a/app/controllers/frontends_controller.rb
+++ b/app/controllers/frontends_controller.rb
@@ -11,7 +11,7 @@ class FrontendsController < InlineFormsController
       redirect_to '/'
     else
       @search_word = params[:word].squish.gsub(CHARACTER_REGEX,'')
-      @word = Word.find_by_name(@search_word)
+      @word = Word.find_by_variant(@search_word)
       if @word.nil?
         render 'palabra_nobo' and return
       end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -109,6 +109,12 @@ class Word < ActiveRecord::Base
     end
   end
 
+  def variants_nice
+    variants_nice = 'Variante ortográfiko: '
+    variants_nice << variants.map { |variant| "#{variant.orthographic_type}: #{variant.lemma}" }.join(', ')
+    variants_nice
+  end
+
   def approved?
    buki_di_oro == 1
   end
@@ -127,6 +133,10 @@ class Word < ActiveRecord::Base
 
   def specific?
     specific > 0
+  end
+
+  def self.find_by_variant(search_variant)
+    Variant.find_by_lemma(search_variant) && Variant.find_by_lemma(search_variant).word
   end
 
   # see http://stackoverflow.com/questions/861448/is-there-a-way-to-avoid-automatically-updating-rails-timestamp-fields

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -136,7 +136,7 @@ class Word < ActiveRecord::Base
   end
 
   def self.find_by_variant(search_variant)
-    Variant.find_by_lemma(search_variant) && Variant.find_by_lemma(search_variant).word
+    Word.joins(:variants).where(variants: { lemma: search_variant }).first
   end
 
   # see http://stackoverflow.com/questions/861448/is-there-a-way-to-avoid-automatically-updating-rails-timestamp-fields

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -135,6 +135,10 @@ class Word < ActiveRecord::Base
     specific > 0
   end
 
+  def varies?
+    variants.count > 1
+  end
+
   def self.find_by_variant(search_variant)
     Word.joins(:variants).where(variants: { lemma: search_variant }).first
   end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -110,9 +110,7 @@ class Word < ActiveRecord::Base
   end
 
   def variants_nice
-    variants_nice = 'Variante ortográfiko: '
-    variants_nice << variants.map { |variant| "#{variant.orthographic_type}: #{variant.lemma}" }.join(', ')
-    variants_nice
+    "Variante ortográfiko: #{variants.map(&:_presentation).join(', ')}"
   end
 
   def approved?

--- a/app/views/frontends/palabra.html.erb
+++ b/app/views/frontends/palabra.html.erb
@@ -21,6 +21,7 @@
       <% end %>
 
       <div class="pap_description bordered">
+        <%= content_tag :p, @word.variants_nice unless @word.variants.count <= 1 %>
         <%= content_tag :p, @word.description_pap_cw_nice %>
         <%= content_tag(:p, @word.synonym) unless @word.synonym.blank? %>
         <%= content_tag(:p, "deskripshon hulandes: #{@word.description_nl}") unless @word.description_nl.blank? %>

--- a/app/views/frontends/palabra.html.erb
+++ b/app/views/frontends/palabra.html.erb
@@ -21,7 +21,7 @@
       <% end %>
 
       <div class="pap_description bordered">
-        <%= content_tag :p, @word.variants_nice unless @word.variants.count <= 1 %>
+        <%= content_tag :p, @word.variants_nice if @word.varies? %>
         <%= content_tag :p, @word.description_pap_cw_nice %>
         <%= content_tag(:p, @word.synonym) unless @word.synonym.blank? %>
         <%= content_tag(:p, "deskripshon hulandes: #{@word.description_nl}") unless @word.description_nl.blank? %>


### PR DESCRIPTION
This is important because making searches by variant, the user don't have to care about which orthographic rules they have to follow. They can type 'alfabetisashon' or 'alfabetisacion' and they get the same word.