### PR TITLE
Added `def human_attribute_name(*args)` to ApplicationRecord class

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def human_attribute_name(*args)
+    self.class.human_attribute_name(*args)
+  end  
 end


### PR DESCRIPTION
Testing on master branch I found that at some point we lost the `def human_attribute_name(*args)`. I tried to find when we lost it but I didn't find which commit remove it in case I was there. I order to get this working again I added this to the ApplicationRecord class instead of adding it thought a file in `config/initializers` because I read in a several places that extending ActiveRecord::Base thought Monkey patching should be avoided: https://stackoverflow.com/questions/2328984/rails-extending-activerecordbase

I wait for your comments! 