### PR TITLE
Added spec for the situation when @objects = nil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,4 +64,5 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'launchy'
+  gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -445,6 +449,7 @@ DEPENDENCIES
   paper_trail
   poltergeist
   rails (~> 5.1.4)
+  rails-controller-testing
   rails-i18n
   rake
   remotipart (~> 1.0)

--- a/spec/controllers/words_controller_spec.rb
+++ b/spec/controllers/words_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe WordsController do
+  describe "GET index" do
+    it "assigns @objects even when update=words_list is not sended" do
+      get :index
+      expect(assigns(:objects)).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
This happends when when update=words_list is not sended and needs to be solved in the inline_forms controller. Once this is solved in the inline_forms gem, this test will pass ok