### PR TITLE
Fixed user registration

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,6 @@
 class RegistrationsController < Devise::RegistrationsController
+  before_action :configure_permitted_parameters
+
   protected
   def after_sign_up_path_for(resource)
     "/auth/users/sign_in?state=after_sign_up"
@@ -12,4 +14,8 @@ class RegistrationsController < Devise::RegistrationsController
     '/?state=password_changed'
   end
 
+  def configure_permitted_parameters
+   devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+   devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
 end


### PR DESCRIPTION
In newest Rails versions because of strong parameters custom devise fields need to be explicitly permitted