### PR TITLE
Auto commit and push

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,11 +16,7 @@ set :linked_dirs, fetch(:linked_dirs, [])
 # Default value for keep_releases is 5
 set :keep_releases, 5
 
-before :deploy do
-  system "bundle install"
-  system "git commit -a"
-  system "git push"
-end
+before :deploy, 'git:push'
 
 before 'rvm1:install:rvm', 'app:update_rvm_key'
 after 'rvm1:install:ruby', 'rvm1:install_bundler'
@@ -61,6 +57,19 @@ namespace :rvm1 do # https://github.com/rvm/rvm1-capistrano3/issues/45
   task :install_bundler do
     on release_roles :all do
       execute "cd #{release_path} && #{fetch(:rvm1_auto_script_path)}/rvm-auto.sh . gem install bundler"
+    end
+  end
+end
+
+namespace :git do
+  desc 'Commiting and pushing to the remote repository'
+  task :push do
+    on roles(:all) do
+      run_locally do
+        execute "bundle install"
+        execute "git commit -a -m 'Auto commit before deploy'"
+        execute "git push"
+      end
     end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,6 +16,12 @@ set :linked_dirs, fetch(:linked_dirs, [])
 # Default value for keep_releases is 5
 set :keep_releases, 5
 
+before :deploy do
+  system "bundle install"
+  system "git commit -a"
+  system "git push"
+end
+
 before 'rvm1:install:rvm', 'app:update_rvm_key'
 after 'rvm1:install:ruby', 'rvm1:install_bundler'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,6 +66,12 @@ namespace :git do
   task :push do
     on roles(:all) do
       run_locally do
+        # Check we are on the master branch, so we can't forget to merge before deploying
+        branch = %x(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \\(.*\\)/\\1/').chomp
+        if branch != "master" && !ENV["IGNORE_BRANCH"]
+          raise RuntimeError, "Not on master branch (set IGNORE_BRANCH=1 to ignore)"
+        end
+
         execute "bundle install"
         execute "git commit -a -m 'Auto commit before deploy'"
         execute "git push"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,15 +66,25 @@ namespace :git do
   task :push do
     on roles(:all) do
       run_locally do
+        # Check for any local changes that haven't been committed
+        status = %x(git status --porcelain).chomp
+        if status != ""
+          ask :answer, "Local git repository has uncommitted changes?. Continue deploying? [Y/N]"
+          unless fetch(:answer).downcase.strip == 'y'
+            puts "Deploy cancelled\n"
+            exit
+          end
+        end
+
         # Check we are on the master branch, so we can't forget to merge before deploying
         branch = %x(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \\(.*\\)/\\1/').chomp
         if branch != "master" && !ENV["IGNORE_BRANCH"]
           raise RuntimeError, "Not on master branch (set IGNORE_BRANCH=1 to ignore)"
         end
 
-        execute "bundle install"
-        execute "git commit -a -m 'Auto commit before deploy'"
-        execute "git push"
+        system "bundle install"
+        system "git commit -a"
+        system "git push"
       end
     end
   end


### PR DESCRIPTION
This PR brings back the auto commit and push before deploy.
Two questions:
* On the current version of «committing and pushing» task before deploy we do an auto commit. Could be better to just notice the developer that there are local changes that haven't been committed? As it is done here: https://gist.github.com/davejamesmiller/2016396  
* The cap deploy fails is there is untracked files. Should we take care of this?

Please, let mi know if any other change is needed and I'll work on it.