### PR TITLE
Fixed WordController specs GET INDEX in order to work ok. Also reverted not needed hot fix

### DIFF
--- a/app/views/_inline_forms_tabs.html.erb
+++ b/app/views/_inline_forms_tabs.html.erb
@@ -7,7 +7,7 @@
           <%= t(controller_name) %>
           <% if current_tab == :word %>
           <% @total_objects = Word.count %>
-             - <span<%= raw " class='red_count'" if (@objects ? @objects.count : 0) < @total_objects %>><%= @objects ? @objects.count : 0 %></span> palabra di <%= @total_objects %>
+             - <span<%= raw " class='red_count'" if @objects.count < @total_objects %>><%= @objects.count %></span> palabra di <%= @total_objects %>
           <% end %>
           </a>
       </h1>

--- a/spec/controllers/words_controller_spec.rb
+++ b/spec/controllers/words_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe WordsController do
   describe "GET index" do
-    it "assigns @objects even when update=words_list is not sended" do
+    it "Successfully" do
+      sign_in create(:user, :superadmin)
       get :index
+      expect(response.status).to eq(200)
       expect(assigns(:objects)).to eq([])
     end
   end


### PR DESCRIPTION
I was wrong, the get index action of InlineFormsController never return @objects equal to nil and the test was not passing because in order to do get index in the WordsController is needed to be logged, because if not, you are redirected to the sign_in path. So, this PR

* Fixes the get index test in order to get it working ok
* Reverts a hot fix that I did and that is not needed https://github.com/acesuares/Papiamentu/commit/53f9561ba697ae725f79b983ba589f31bd12946a

Once, this PR is merged all tests should be passing successfully.